### PR TITLE
Update Waterpark API

### DIFF
--- a/ryo-pools.json
+++ b/ryo-pools.json
@@ -183,7 +183,7 @@
         {
             "name" : "Waterpark",
             "url" : "https://www.waterparkmining.com/pools/ryo",
-            "api" : "https://api.waterparkmining.com/ryo/",
+            "api" : "https://api.waterparkmining.com/pools/ryo/",
             "type" : "go",
             "location" : "",
             "payment": ["pplns","solo"],


### PR DESCRIPTION
I've decided I want the pool stats url and the pool website url to match, since it makes it easier for me to keep things in order.

The old URL still works, but once I see this merged and deployed, I'll remove it.

Sorry for the trouble! New url verify: http://api.waterparkmining.com/pools/ryo/stats