### PR TITLE
leaf pool is no longer mining Ryo

### DIFF
--- a/ryo-pools.json
+++ b/ryo-pools.json
@@ -19,15 +19,6 @@
             "miningAddress" : "ryo.miner.rocks"
         },
         {
-            "name" : "Leaf Pool",
-            "url" : "https://ryo.leafpool.com/",
-            "api" : "https://api-ryo.leafpool.com/",
-            "type" : "cryptonote-universal",
-            "location" : "",
-            "payment": ["prop"],
-            "miningAddress" : "mine-ryo.leafpool.com"
-        },
-        {
             "name" : "Hero Miners",
             "url" : "https://ryo.herominers.com/",
             "api" : "https://ryo.herominers.com/api/",


### PR DESCRIPTION
Display on it's website:

> Our RYO Pool is no longer active. Please choose a different coin to mine. If you want to request a new coin you can send them at our telegram group https://t.me/Leafpool_Mining 